### PR TITLE
Fix crash on Aegisub 3.2 due to missing extradata

### DIFF
--- a/macros/phos.svg2ass.lua
+++ b/macros/phos.svg2ass.lua
@@ -174,6 +174,7 @@ local function string2line(str)
 	l2.margin_t = margv
 	l2.effect = eff
 	l2.text = txt
+	l2.extra = {}
 	return l2
 end
 


### PR DESCRIPTION
This crash has been [fixed](https://github.com/Aegisub/Aegisub/commit/88d8573d4ca1c41e30c68e1e2da9b7eb1ad1b86f) even in official Aegisub, but only after version 3.2. Thus, it's still present in multiple official releases and package repositories.