### PR TITLE
[Timing Assistant] Fix missing space in line linking

### DIFF
--- a/macros/phos.TimingAssistant.moon
+++ b/macros/phos.TimingAssistant.moon
@@ -137,7 +137,7 @@ timeStart = (sub, sel, opt) ->
         debugMsg "Link lines failed because a keyframe is close. Snap end of last line. Add lead in to current line."
 
       elseif (startTime - opt.startLeadIn) > (getTime(nextKeyframe) - 500)
-        line.start_time = getTime(nextKeyframe) -500 unless snap
+        line.start_time = getTime(nextKeyframe) - 500 unless snap
         previousLine.end_time = line.start_time
         debugMsg "Link lines by ensuring that start time is 500 ms away from next keyframe."
 


### PR DESCRIPTION
For some reason, moonscript compiles this very differently with just a single space on one side, instead of on both.

The former produces `getTime(nextKeyframe)(-500)`.
This is deeply concerning.