### PR TITLE
[TimingAssistant] Separate start keyframe snap parameters

### DIFF
--- a/macros/phos.TimingAssistant.moon
+++ b/macros/phos.TimingAssistant.moon
@@ -1,6 +1,6 @@
 export script_name = "Timing Assistant"
 export script_description = "A second brain for timers."
-export script_version = "1.0.1"
+export script_version = "1.1.0"
 export script_author = "PhosCity"
 export script_namespace = "phos.TimingAssistant"
 
@@ -13,7 +13,8 @@ logger = depctrl\getLogger!
 getTime, getFrame = aegisub.ms_from_frame, aegisub.frame_from_ms
 defaultConfig =
   startLeadIn: 120
-  startKeysnap: 350
+  startKeysnapBefore: 350
+  startKeysnapAfter: 350
   startLink: 620
   endLeadOut: 400
   endKeysnapBefore: 300
@@ -31,12 +32,13 @@ configSetup = ->
 		{x: 3, y: 0,  width: 1, height: 1, class: "checkbox", label: "Debug", name: "debug", value: config.c.debug, hint: "Disply debugging messages"}
   }
   data = {
-    {"Lead in",         "startLeadIn",      config.c.startLeadIn,      "100-150 ms",  "Lead in amound from exact start"}
-    {"Key Snap",        "startKeysnap",     config.c.startKeysnap,     "~2*leadin",   "Time to snap to keyframe from exact start"}
-    {"Line Link",       "startLink",        config.c.startLink,        "~500+leadin", "Time from exact start of current line to end-time of previous line to link"}
-    {"Lead out",        "endLeadOut",       config.c.endLeadOut,       "350-450 ms",  "Lead out amount from exact end"}
-    {"Key Snap Before", "endKeysnapBefore", config.c.endKeysnapBefore, "100-300 ms",  "Time to snap to keyframe before the exact end"}
-    {"Key Snap After",  "endKeysnapAfter",  config.c.endKeysnapAfter,  "800-1000 ms", "Time to snap to keyframe after the exact end"}
+    {"Lead in",         "startLeadIn",        config.c.startLeadIn,        "100-150 ms",  "Lead in amound from exact start"}
+    {"Key Snap",        "startKeysnapBefore", config.c.startKeysnapBefore, "~2*leadin",   "Time to snap to keyframe before the exact start"}
+    {"Key Snap",        "startKeysnapAfter",  config.c.startKeysnapAFter,  "~2*leadin",   "Time to snap to keyframe after the exact start"}
+    {"Line Link",       "startLink",          config.c.startLink,          "~500+leadin", "Time from exact start of current line to end-time of previous line to link"}
+    {"Lead out",        "endLeadOut",         config.c.endLeadOut,         "350-450 ms",  "Lead out amount from exact end"}
+    {"Key Snap Before", "endKeysnapBefore",   config.c.endKeysnapBefore,   "100-300 ms",  "Time to snap to keyframe before the exact end"}
+    {"Key Snap After",  "endKeysnapAfter",    config.c.endKeysnapAfter,    "800-1000 ms", "Time to snap to keyframe after the exact end"}
   }
   for index, item in ipairs data
     dlg[#dlg+1] = {x: 0, y: y,   width: 5, height: 1, class: "label",   label: item[5]}
@@ -52,7 +54,8 @@ configSetup = ->
   saveSource = defaultConfig if btn == "Reset"
   with saveSource
     opt.startLeadIn = .startLeadIn
-    opt.startKeysnap = .startKeysnap
+    opt.startKeysnapBefore = .startKeysnapBefore
+    opt.startKeysnapAfter = .startKeysnapAfter
     opt.startLink = .startLink
     opt.endLeadOut = .endLeadOut
     opt.endKeysnapBefore = .endKeysnapBefore
@@ -117,11 +120,11 @@ timeStart = (sub, sel, opt) ->
 
     -- Keyframe Snapping
     previousKeyframe, nextKeyframe = findAdjacentKeyframes startTime
-    if math.abs(getTime(previousKeyframe) - startTime) < opt.startKeysnap
+    if math.abs(getTime(previousKeyframe) - startTime) < opt.startKeysnapBefore
       line.start_time = getTime previousKeyframe
       snap = true
       debugMsg "Keyframe snap behind"
-    if math.abs(getTime(nextKeyframe) - startTime) < opt.startKeysnap and not snap
+    if math.abs(getTime(nextKeyframe) - startTime) < opt.startKeysnapAfter and not snap
       line.start_time = getTime nextKeyframe
       snap = true
       debugMsg "Keyframe snap ahead"

--- a/macros/phos.TimingAssistant.moon
+++ b/macros/phos.TimingAssistant.moon
@@ -14,7 +14,7 @@ getTime, getFrame = aegisub.ms_from_frame, aegisub.frame_from_ms
 defaultConfig =
   startLeadIn: 120
   startKeysnapBefore: 350
-  startKeysnapAfter: 350
+  startKeysnapAfter: 100
   startLink: 620
   endLeadOut: 400
   endKeysnapBefore: 300
@@ -27,14 +27,14 @@ config = depctrl\getConfigHandler defaultConfig
 configSetup = ->
   y, dlg = 1,  {
 		{x: 0, y: 0,  width: 1, height: 1, class: "label",    label: "Start:"}
-		{x: 0, y: 8,  width: 1, height: 1, class: "label",    label: "End:"}
-		{x: 0, y: 16, width: 5, height: 1, class: "checkbox", label: "Auto-move to next line after making changes", name: "automove", value: config.c.automove}
+		{x: 0, y: 10, width: 1, height: 1, class: "label",    label: "End:"}
+		{x: 0, y: 18, width: 5, height: 1, class: "checkbox", label: "Auto-move to next line after making changes", name: "automove", value: config.c.automove}
 		{x: 3, y: 0,  width: 1, height: 1, class: "checkbox", label: "Debug", name: "debug", value: config.c.debug, hint: "Disply debugging messages"}
   }
   data = {
     {"Lead in",         "startLeadIn",        config.c.startLeadIn,        "100-150 ms",  "Lead in amound from exact start"}
-    {"Key Snap",        "startKeysnapBefore", config.c.startKeysnapBefore, "~2*leadin",   "Time to snap to keyframe before the exact start"}
-    {"Key Snap",        "startKeysnapAfter",  config.c.startKeysnapAFter,  "~2*leadin",   "Time to snap to keyframe after the exact start"}
+    {"Key Snap Before", "startKeysnapBefore", config.c.startKeysnapBefore, "~2*leadin",   "Time to snap to keyframe before the exact start"}
+    {"Key Snap After",  "startKeysnapAfter",  config.c.startKeysnapAFter,  "0-100 ms",   "Time to snap to keyframe after the exact start"}
     {"Line Link",       "startLink",          config.c.startLink,          "~500+leadin", "Time from exact start of current line to end-time of previous line to link"}
     {"Lead out",        "endLeadOut",         config.c.endLeadOut,         "350-450 ms",  "Lead out amount from exact end"}
     {"Key Snap Before", "endKeysnapBefore",   config.c.endKeysnapBefore,   "100-300 ms",  "Time to snap to keyframe before the exact end"}
@@ -45,7 +45,7 @@ configSetup = ->
     dlg[#dlg+1] = {x: 0, y: y+1, width: 1, height: 1, class: "label",   label: item[1]}
     dlg[#dlg+1] = {x: 1, y: y+1, width: 1, height: 1, class: "intedit", name: item[2], value: item[3]}
     dlg[#dlg+1] = {x: 3, y: y+1, width: 1, height: 1, class: "label",   label: "Recommended value: #{item[4]}"}
-    if index %3 == 0 y += 4 else y += 2
+    if index %4 == 0 y += 4 else y += 2
 
   btn, res = aegisub.dialog.display dlg, { "Save", "Reset", "Cancel" }
   aegisub.cancel! if btn == "Cancel"


### PR DESCRIPTION
This has bugged me for quite a while. If a line starts a little bit after a keyframe, the script will happily snap the start to it, completely disregarding any leadin at all—especially bad if it's a fake keyframe.

Because the start snapping only has one parameter, the user can't control this behavior at all, even though usually it's quite undesired. Note also that the snap distance is considered _before_ leadin is applied, so essentially any "forwards" snapping will always cause negative leadin.

This PR splits the parameters similarly to end kf snapping, and sets the default value to a more sane 100 ms.

Notably, as it renames the saved config value name, this will _not_ respect the previous value set for `startKeysnap`, if one exists; the user would need to re-configure the value themselves.